### PR TITLE
Implementing tag_key support

### DIFF
--- a/core/components/tagger/elements/snippets/taggergetresourceswhere.snippet.php
+++ b/core/components/tagger/elements/snippets/taggergetresourceswhere.snippet.php
@@ -33,6 +33,35 @@ if ($where == false) {
 }
 
 if ($tags == '') {
+
+    if (!empty($_GET[$tagKey])) {
+        $tagList = $tagger->explodeAndClean($_GET[$tagKey]);
+
+        if (!empty($tagList)) {
+            $conditions = array('AND:TaggerTag.alias:IN' => $tagList);
+
+            if ($likeComparison == 1) {
+                foreach ($tagList as $tag) {
+                    $conditions[] = array('OR:TaggerTag.alias:LIKE' => '%' . $tag . '%');
+                }
+            }
+        }
+
+        if (!empty($conditions)) {
+            $c = $modx->newQuery('TaggerTagResource');
+            $c->select('TaggerTagResource.resource');
+            $c->innerJoin('TaggerTag', '', array('TaggerTag.id = TaggerTagResource.tag'));
+            $c->where($conditions);
+            $c->groupby('TaggerTagResource.resource');
+            $c->prepare();
+            $where[] = 'modResource.id IN(' . $c->toSQL() . ')';
+            $c = null;
+        }
+
+        // Ignore other GET parameters
+        return $modx->toJSON($where);
+    }
+
     $gc = $modx->newQuery('TaggerGroup');
     $gc->select($modx->getSelectColumns('TaggerGroup', '', '', array('alias')));
     $gc->prepare();


### PR DESCRIPTION
Snippet uses `$_GET[ tagger.tag_key ]` and  create where based on tag aliases.
