### PR TITLE
Added ability to select the TaggerTag column to search against (in Tagge...

### DIFF
--- a/core/components/tagger/elements/snippets/taggergetresourceswhere.snippet.php
+++ b/core/components/tagger/elements/snippets/taggergetresourceswhere.snippet.php
@@ -24,6 +24,7 @@ if (!($tagger instanceof Tagger)) return '';
 
 $tags = $modx->getOption('tags', $scriptProperties, '');
 $where = $modx->getOption('where', $scriptProperties, '');
+$tagField = $modx->getOption('tagField', $scriptProperties, 'alias');
 $likeComparison = (int) $modx->getOption('likeComparison', $scriptProperties, 0);
 
 $where = $modx->fromJSON($where);
@@ -82,7 +83,7 @@ if ($tags == '') {
     $c->select($modx->getSelectColumns('TaggerTag', 'TaggerTag', '', array('id')));
 
     $compare = array(
-        'alias:IN' => $tags
+        "{$tagField}:IN" => $tags
     );
 
     if ($likeComparison == 1) {


### PR DESCRIPTION
...rGetResourcesWhere) using the parameter &tagField

Obviously, it only make sense for `TaggerTag.tag`

Use case is to be able to display the "human readable" tag (ie. in a header) & use it in the snippet
