### PR TITLE
Fix: updating hidden textfield

### DIFF
--- a/assets/components/tagger/js/mgr/extras/tagger.tagfield.js
+++ b/assets/components/tagger/js/mgr/extras/tagger.tagfield.js
@@ -471,6 +471,9 @@ Ext.extend(Tagger.fields.Tag,Ext.Component, {
             }
             var record = new Ext.data.Record({tag: this.value}, this.value);
             this.owner.myStore.add([record]);
+            if(this.owner.hiddenField){
+                this.owner.hiddenField.value = this.owner.myStore.collect('tag').join();
+            }
 
             this.el.addClass('x-superboxselect-item');
             this.el.addClass('modx-tag-checked');


### PR DESCRIPTION
was not possible to accept new tags with hidden textfield (not recorded to the hidden field), but all accept after remove tag.
