### PR TITLE
Add tag contain only UTF8 symbols

### DIFF
--- a/core/components/tagger/model/tagger/taggertag.class.php
+++ b/core/components/tagger/model/tagger/taggertag.class.php
@@ -16,7 +16,7 @@ class TaggerTag extends xPDOSimpleObject {
     public function cleanAlias($tag) {
         $res = new modResource($this->xpdo);
         $tag = str_replace('/', '-', $tag);
-        $tag = iconv('UTF-8', 'ASCII//TRANSLIT', $tag);
+        //$tag = iconv('UTF-8', 'ASCII//TRANSLIT', $tag);
         
         return $res->cleanAlias($tag);
     }


### PR DESCRIPTION
If I add tag contain only UTF8 symbols his alias as empty and resource never save.