### PR TITLE
Bug Fix: Add Label to getCurrentTags

### DIFF
--- a/core/components/tagger/elements/snippets/taggergetcurrenttag.snippet.php
+++ b/core/components/tagger/elements/snippets/taggergetcurrenttag.snippet.php
@@ -77,6 +77,7 @@ foreach ($currentTags as $currentTag) {
         
         $phs = array (
             'tag' => $tag['tag'],
+            'label' => $tag['label'],
             'alias' => $tag['alias'],
             'uri' => $uri,
             'group_name' => $currentTag['group'],

--- a/core/components/tagger/model/tagger/tagger.class.php
+++ b/core/components/tagger/model/tagger/tagger.class.php
@@ -115,6 +115,7 @@ class Tagger {
                         if ($tag) {
                             $tags[$tag->alias] = array(
                                 'tag' => $tag->tag,
+                                'label' => $tag->label,
                                 'alias' => $tag->alias
                             );
                         } else {


### PR DESCRIPTION
# Why is it needed

Tag labels that were introduced in 1.10.0-pl were not added to the getCurrentTags function or snippet.

# What it does

Adds the tag label to the getCurrentTags() function's return for tags and as a placeholder for the TaggerGetCurrentTag snippet. 