### PR TITLE
Pass scriptProperties into chunk placeholders prefixed

### DIFF
--- a/core/components/tagger/elements/snippets/taggergettags.snippet.php
+++ b/core/components/tagger/elements/snippets/taggergettags.snippet.php
@@ -184,9 +184,14 @@ if ($linkCurrentTags == 1) {
     }
 }
 
+$phsBase = array();
+foreach($scriptProperties as $prop => $value) {
+    $phsBase['sp.' . $prop] = $value;
+}
+
 foreach ($tags as $tag) {
     /** @var TaggerTag $tag */
-    $phs = $tag->toArray();
+    $phs = array_merge($phsBase, $tag->toArray());
 
     $group = $tag->Group;
 
@@ -249,7 +254,6 @@ foreach ($tags as $tag) {
     }
 
     $rowTpl = $defaultRowTpl;
-    $phs['sp'] = $scriptProperties;
 
     if ($rowTpl == '') {
         $out[] = '<pre>' . print_r($phs, true) . '</pre>';


### PR DESCRIPTION
### Why is it Needed?

Currently the TaggerGetTags snippet adds the script properties to the chunk rendering as is (e.g. an array) which isn't accessible in the chunk.

### What does it do?

This change introduces a new `$phsBase` array which the script properties are looped and added to prefixed with `sp.` like the current code. Then for each tag loop it merges `$phsBase` with the `$tag->toArray()` and remove the old `$phs['sp']` code.