### PR TITLE
Add 404 handler for invalid tags

### DIFF
--- a/core/components/tagger/elements/snippets/taggergetresourceswhere.snippet.php
+++ b/core/components/tagger/elements/snippets/taggergetresourceswhere.snippet.php
@@ -31,7 +31,7 @@ $where = $modx->getOption('where', $scriptProperties, '');
 $tagField = $modx->getOption('tagField', $scriptProperties, 'alias');
 $likeComparison = (int) $modx->getOption('likeComparison', $scriptProperties, 0);
 $matchAll = (int) $modx->getOption('matchAll', $scriptProperties, 0);
-$errorOnInvalidTags = $modx->getOption('errorOnInvalidTags', $scriptProperties, false);
+$errorOnInvalidTags = (int) $modx->getOption('errorOnInvalidTags', $scriptProperties, 0);
 $field = $modx->getOption('field', $scriptProperties, 'id');
 $where = $modx->fromJSON($where);
 if ($where == false) {
@@ -132,7 +132,7 @@ $tagIDs = $c->stmt->fetchAll(PDO::FETCH_COLUMN, 0);
 
 if (count($tagIDs) == 0) {
     $tagIDs[] = 0;
-    if($errorOnInvalidTags)
+    if($errorOnInvalidTags == 1)
         $modx->sendForward($modx->getOption('error_page'),array('response_code' => 'HTTP/1.1 404 Not Found'));
 }
 

--- a/core/components/tagger/elements/snippets/taggergetresourceswhere.snippet.php
+++ b/core/components/tagger/elements/snippets/taggergetresourceswhere.snippet.php
@@ -14,6 +14,7 @@
  * &likeComparison  int     optional    If set to 1, tags will compare using LIKE
  * &tagField        string  optional    Field that will be used to compare with given tags. Default: alias
  * &matchAll        int     optional    If set to 1, resource must have all specified tags. Default: 0
+ * &errorOnInvalidTags bool optional    If set to true, will 404 on an invalid tag name request. Default: false
  * &field           string  optional    modResource field that will be used to compare with assigned resource ID
  *
  * USAGE:
@@ -30,6 +31,7 @@ $where = $modx->getOption('where', $scriptProperties, '');
 $tagField = $modx->getOption('tagField', $scriptProperties, 'alias');
 $likeComparison = (int) $modx->getOption('likeComparison', $scriptProperties, 0);
 $matchAll = (int) $modx->getOption('matchAll', $scriptProperties, 0);
+$errorOnInvalidTags = $modx->getOption('errorOnInvalidTags', $scriptProperties, false);
 $field = $modx->getOption('field', $scriptProperties, 'id');
 $where = $modx->fromJSON($where);
 if ($where == false) {
@@ -130,6 +132,8 @@ $tagIDs = $c->stmt->fetchAll(PDO::FETCH_COLUMN, 0);
 
 if (count($tagIDs) == 0) {
     $tagIDs[] = 0;
+    if($errorOnInvalidTags)
+        $modx->sendForward($modx->getOption('error_page'),array('response_code' => 'HTTP/1.1 404 Not Found'));
 }
 
 if ($matchAll == 0) {


### PR DESCRIPTION
A basic fix to the TaggerGetResourcesWhere snippet that optionally sends a 404 error response if an invalid tag is selected. 